### PR TITLE
fix L1 distance function

### DIFF
--- a/Module04_BackProp/auto_grad/HW_assignment.ipynb
+++ b/Module04_BackProp/auto_grad/HW_assignment.ipynb
@@ -730,7 +730,7 @@
     "        Number : the L1 loss (absolute error) of `model_params` evaluated on `truth`\n",
     "    '''\n",
     "    l = truth[0] - model[0] - sum(truth[i]*model[i] for i in range(1, len(model)))\n",
-    "    return l if l.data > 0 else (-1*l)**2"
+    "    return l if l.data > 0 else -1*l"
    ]
   },
   {


### PR DESCRIPTION
Remove mistaken squaring while taking absolute value for L1 distance